### PR TITLE
Update version to 1.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 {% set version = "1.4.8" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scramp" %}
-{% set version = "1.4.6" %}
+{% set version = "1.4.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,18 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fe055ebbebf4397b9cb323fcc4b299f219cd1b03fd673ca40c97db04ac7d107e
+  sha256: bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: True  # [py<310]
 
 requirements:
   host:
     - pip
     - python
     - hatchling
+    - versioningit
   run:
     - python
     - asn1crypto >=1.5.1
@@ -37,7 +38,7 @@ test:
     - pytest-mock
 
 about:
-  home: https://github.com/tlocke/scramp
+  home: https://codeberg.org/tlocke/scramp
   summary: A pure-Python implementation of the SCRAM authentication protocol
   license: MIT
   license_family: MIT
@@ -45,8 +46,8 @@ about:
   description: |
     A Python implementation of the SCRAM authentication protocol defined by
     RFC 5802 and RFC 7677.
-  dev_url: https://github.com/tlocke/scramp
-  doc_url: https://github.com/tlocke/scramp/blob/main/README.md
+  dev_url: https://codeberg.org/tlocke/scramp
+  doc_url: https://codeberg.org/tlocke/scramp/src/branch/main/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
scramp 1.4.8

**Destination channel:** defaults

### Links

- [PKG-15729](https://anaconda.atlassian.net/browse/PKG-15729) 
- [Upstream repository](https://codeberg.org/tlocke/scramp)

### Explanation of changes:
- New version number
- Updated dependency
- Updated source link (github link is not available anymore)


[PKG-15729]: https://anaconda.atlassian.net/browse/PKG-15729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ